### PR TITLE
Fix deprecated use of XML Element.getchildren()

### DIFF
--- a/otrs/client.py
+++ b/otrs/client.py
@@ -264,7 +264,7 @@ class OperationBase(object):
         @param element : a etree.Element
         @return        : a list of etree.Element
         """
-        return element.getchildren()[0].getchildren()[0].getchildren()
+        return list(list(list(element)[0])[0])
 
     @staticmethod
     def _unpack_resp_one(element):
@@ -273,7 +273,7 @@ class OperationBase(object):
         @param element : a etree.Element
         @return        : a etree.Element (first child of the response)
         """
-        return element.getchildren()[0].getchildren()[0].getchildren()[0]
+        return list(list(list(element)[0])[0])[0]
 
     def _pack_req(self, element):
         """Pack an etree Element.

--- a/otrs/client.py
+++ b/otrs/client.py
@@ -61,7 +61,7 @@ class SOAPError(OTRSError):
 
     def __init__(self, tag):
         """Initialize OTRS SOAPError."""
-        d = {extract_tagname(i): i.text for i in tag.getchildren()}
+        d = {extract_tagname(i): i.text for i in list(tag)}
         self.errcode = d['ErrorCode']
         self.errmsg = d['ErrorMessage']
 
@@ -349,6 +349,8 @@ class GenericInterfaceClient(object):
         self.ssl_context = ssl_context
         self.giurl = urljoin(
             server, 'otrs/nph-genericinterface.pl/Webservice/')
+
+        print("This is local python-otrs")
 
         if timeout is None:
             self.timeout = socket._GLOBAL_DEFAULT_TIMEOUT

--- a/otrs/objects.py
+++ b/otrs/objects.py
@@ -56,7 +56,7 @@ class OTRSObject(object):
                     cls.XML_NAME, xml_element.tag))
         attrs = {}
         childs = []
-        for t in xml_element.getchildren():
+        for t in list(xml_element):
             name = extract_tagname(t)
             if name in child_tags:
                 # Complex child tags

--- a/tests.py
+++ b/tests.py
@@ -337,7 +337,7 @@ class TestObjects(unittest.TestCase):
     def test_ticket_to_xml(self):
         t = Ticket(State='open', Priority='3 normal', Queue='Postmaster')
         xml = t.to_xml()
-        xml_childs = xml.getchildren()
+        xml_childs = list(xml)
 
         xml_childs_dict = {i.tag: i.text for i in xml_childs}
 


### PR DESCRIPTION
This fixes a deprecated call to xml.etree.ElementTree.Element.getchildren()