### PR TITLE
Fix autocast of None values

### DIFF
--- a/otrs/objects.py
+++ b/otrs/objects.py
@@ -158,6 +158,8 @@ def autocast(s):
             return float(s)
         except ValueError:
             return s
+    except TypeError:
+        return s
 
 
 class Attachment(OTRSObject):


### PR DESCRIPTION
Fix autocast of `None` values (`NoneType` cannot be an `int()` argument).

**Error**: `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`.
**Fix**: Handle `TypeError`  exception in `autocast()`.