### PR TITLE
Fix multiselection free fields to return all selected values

### DIFF
--- a/otrs/objects.py
+++ b/otrs/objects.py
@@ -64,8 +64,15 @@ class OTRSObject(object):
                 sub_obj = SubClass.from_xml(t)
                 childs.append(sub_obj)
             else:
-                # Simple child tags
-                attrs[name] = t.text
+                if name in attrs:
+                    # Multivalue child tags
+                    if type(attrs[name]) is list:
+                        attrs[name] += [t.text]
+                    else:
+                        attrs[name] = [ attrs[name], t.text ] # Convert to list
+                else:
+                    # Simple child tags
+                    attrs[name] = t.text
         obj = cls(**attrs)
 
         for i in childs:


### PR DESCRIPTION
Multiselection free fields can return multiple values. The actual implementation of `from_xml()` overwrites the `attrs[name] = t.text` without checking if `name` is already in `attrs`.

This PR fixes multiselection free fields to return an array of values (not just the last one) when more than one value per key is provided.